### PR TITLE
docs: fix console command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Now the creation of the article can be done.
 ### How to use
 
 1) <pre>$ docker-compose exec php sh</pre>
-2) Create user: <pre>$ bin/concole app:create-user s.alletti@gmail.com p4$$word ROLE_EDITOR</pre>
+2) Create user: <pre>$ bin/console app:create-user s.alletti@gmail.com p4$$word ROLE_EDITOR</pre>
 3) Create category: <pre>POST https://localhost/api/categories/ </pre>
     <pre>
     {


### PR DESCRIPTION
## Summary
- Fix the README user creation command from `bin/concole` to `bin/console`.
- Leave the documented `app:create-user` command and arguments unchanged.

Fixes #2.

## Validation
- Confirmed `bin/console` exists in this repository.
- Confirmed `src/Blog/User/Application/Command/CreateUserCommand.php` registers `app:create-user`.
- Ran `rg -n "concole|bin/console app:create-user|app:create-user" README.md bin src`.
- Ran `git diff --check`.

I could not run PHP syntax/runtime checks locally because this environment does not have a `php` binary installed.